### PR TITLE
Enable RGBA32 for texture data and removing an 8 bit limit on the att…

### DIFF
--- a/build/three.js
+++ b/build/three.js
@@ -30384,7 +30384,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	var maxVertexAttributes = gl.getParameter( gl.MAX_VERTEX_ATTRIBS );
 	var newAttributes = new Uint8Array( maxVertexAttributes );
 	var enabledAttributes = new Uint8Array( maxVertexAttributes );
-	var attributeDivisors = new Uint8Array( maxVertexAttributes );
+	var attributeDivisors = new Uint32Array( maxVertexAttributes );
 
 	var capabilities = {};
 
@@ -31745,8 +31745,15 @@ THREE.WebGLTextures = function ( _gl, extensions, state, properties, capabilitie
 			// need to change this internal format for WebGL2 in onr of our data textures
 			let glChangedInternalFormat = glFormat;
 			if(_isWebGL2) {
-				if(texture.type === THREE.FloatType && glFormat === _gl.RGB) {
-					glChangedInternalFormat = _gl.RGB32F;
+				if(texture.type === THREE.FloatType) {
+          if(glFormat === _gl.RGB)
+          {
+            glChangedInternalFormat = _gl.RGB32F;
+          }
+          else if(glFormat === _gl.RGBA)
+          {
+            glChangedInternalFormat = _gl.RGBA32F;
+          }
 				}
 			}
 

--- a/src/renderers/webgl/WebGLState.js
+++ b/src/renderers/webgl/WebGLState.js
@@ -15,7 +15,7 @@ THREE.WebGLState = function ( gl, extensions, paramThreeToGL ) {
 	var maxVertexAttributes = gl.getParameter( gl.MAX_VERTEX_ATTRIBS );
 	var newAttributes = new Uint8Array( maxVertexAttributes );
 	var enabledAttributes = new Uint8Array( maxVertexAttributes );
-	var attributeDivisors = new Uint8Array( maxVertexAttributes );
+	var attributeDivisors = new Uint32Array( maxVertexAttributes );
 
 	var capabilities = {};
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -450,8 +450,15 @@ THREE.WebGLTextures = function ( _gl, extensions, state, properties, capabilitie
 			// need to change this internal format for WebGL2 in onr of our data textures
 			let glChangedInternalFormat = glFormat;
 			if(_isWebGL2) {
-				if(texture.type === THREE.FloatType && glFormat === _gl.RGB) {
-					glChangedInternalFormat = _gl.RGB32F;
+				if(texture.type === THREE.FloatType) {
+          if(glFormat === _gl.RGB)
+          {
+            glChangedInternalFormat = _gl.RGB32F;
+          }
+          else if(glFormat === _gl.RGBA)
+          {
+            glChangedInternalFormat = _gl.RGBA32F;
+          }
 				}
 			}
 


### PR DESCRIPTION
* internal notes. 
     I need to be able to create RGBA32F texture for some position and weight data for the instances. So I don't need to create two sets of textures.
     I also changed the Uint8Array to be a Uint32Array just so that we are not limited to 255 items per instance.